### PR TITLE
Move outerTemplate docs out of Work/sub-modules

### DIFF
--- a/sub-modules/Miscellaneous/README.md
+++ b/sub-modules/Miscellaneous/README.md
@@ -2,7 +2,7 @@
 
 **npm package:** `atherdon-newsletter-js-layouts-misc` · **version:** 3.0.0
 
-> Part of the [Work/sub-modules](../README.md) component library.
+> Part of the [sub-modules](../README.md) component library.
 
 ## Purpose
 

--- a/sub-modules/README.md
+++ b/sub-modules/README.md
@@ -1,4 +1,4 @@
-# Work/sub-modules
+# sub-modules
 
 This directory contains the independently-published npm packages that make up the HN Email Template component system. Each sub-module is a self-contained library that can be installed, built, and tested on its own.
 
@@ -23,7 +23,7 @@ Work/ (atherdon-old-newsletter-js-outertemplate)
 
 ## Adding a new module
 
-1. Create a directory under `Work/sub-modules/<ModuleName>/`.
+1. Create a directory under `sub-modules/<ModuleName>/`.
 2. Inside it, initialise a package with the naming convention `atherdon-newsletter-js-layouts-<name>`.
 3. Add the standard toolchain files: `package.json`, `rollup.config.js`, `.babelrc`, `.eslintrc.json`, `.prettierrc`, `.eslintignore`, `.prettierignore`, `.npmignore`, `.gitignore`.
 4. Put source code under `src/` with a single `src/index.js` entry point that exports a plain object of components.
@@ -36,7 +36,7 @@ Work/ (atherdon-old-newsletter-js-outertemplate)
    - Dependencies
    - Build / test / lint commands
    - Known limitations / TODOs
-7. Add a row for the new module in the table above and link it back to `Work/sub-modules/README.md`.
+7. Add a row for the new module in the table above and link it back to `sub-modules/README.md`.
 
 ## Validation pattern
 

--- a/sub-modules/Typography/README.md
+++ b/sub-modules/Typography/README.md
@@ -2,7 +2,7 @@
 
 **npm package:** `atherdon-newsletter-js-layouts-typography` · **version:** 3.1.0
 
-> Part of the [Work/sub-modules](../README.md) component library.
+> Part of the [sub-modules](../README.md) component library.
 
 ## Purpose
 

--- a/sub-modules/innerComponents/README.md
+++ b/sub-modules/innerComponents/README.md
@@ -2,7 +2,7 @@
 
 **npm package:** `atherdon-newsletter-js-layouts-body` · **version:** 3.2.0
 
-> Part of the [Work/sub-modules](../README.md) component library.
+> Part of the [sub-modules](../README.md) component library.
 
 ## Purpose
 

--- a/sub-modules/outerTemplate/README.md
+++ b/sub-modules/outerTemplate/README.md
@@ -1,6 +1,6 @@
 # outerTemplate
 
-> Part of the [Work/sub-modules](../README.md) component library.
+> Part of the [sub-modules](../README.md) component library.
 
 ## Purpose
 
@@ -22,4 +22,4 @@ When implemented, this module should:
 
 - No `package.json`, `src/`, or `rollup.config.js` present — the module is not buildable or publishable yet.
 - Migrate or extract the relevant code from `Work/` into this directory to make it a proper standalone package.
-- Once implemented, add an npm package name (suggested: `atherdon-newsletter-js-layouts-outertemplate`) and register it in the dependency graph documented in [Work/sub-modules/README.md](../README.md).
+- Once implemented, add an npm package name (suggested: `atherdon-newsletter-js-layouts-outertemplate`) and register it in the dependency graph documented in [sub-modules/README.md](../README.md).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- move `Work/sub-modules/outerTemplate/README.md` to `sub-modules/outerTemplate/README.md`
- move `Work/sub-modules/README.md` to `sub-modules/README.md`
- update sub-module README references to point to the new `sub-modules/README.md` location

## Notes
- `outerTemplate` remains a documentation stub (no package source files yet)
- this PR only moves/updates documentation paths to align with prior module moves
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ba175c5-e994-4dd1-bbbf-45a0c6bfe105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ba175c5-e994-4dd1-bbbf-45a0c6bfe105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

