### PR TITLE
Add shared validation for core template components

### DIFF
--- a/Work/src/components/body.js
+++ b/Work/src/components/body.js
@@ -1,20 +1,33 @@
+import { validateInput } from './validation/validateInput';
+
 const EmailTemplateBodyComponent = (params) => {
-  const { footer, logoTop, logoBottom, content, previewText } = params;
+  const { footer, logoTop, logoBottom, content, previewText } = params || {};
 
   // console.log(logoTop);
   // console.log(logoBottom);
 
-  if (!footer) {
-    throw new Error('no footer was passed');
-  }
-
-  if (!logoTop || !logoBottom) {
-    throw new Error('invalid logo');
-  }
-
-  if (!previewText) {
-    throw new Error('invalid preview text');
-  }
+  validateInput(params, [
+    {
+      field: 'footer',
+      errorMessage: 'no footer was passed',
+      rules: ['required', 'nonEmptyString'],
+    },
+    {
+      field: 'logoTop',
+      errorMessage: 'invalid logo',
+      rules: ['required', 'nonEmptyString'],
+    },
+    {
+      field: 'logoBottom',
+      errorMessage: 'invalid logo',
+      rules: ['required', 'nonEmptyString'],
+    },
+    {
+      field: 'previewText',
+      errorMessage: 'invalid preview text',
+      rules: ['required', 'nonEmptyString'],
+    },
+  ]);
 
   return `<body
     style="

--- a/Work/src/components/footer.js
+++ b/Work/src/components/footer.js
@@ -1,37 +1,7 @@
+import { validateInput } from './validation/validateInput';
+
 const renderCustomBlock = (params) => {
-
-
   const { address, sponsor, copyright, unsubscribe } = params;
-
-
-  if (!copyright) {
-    throw new Error('no copyrights was passed');
-  }
-  // if (typeof copyright != 'function') {
-  //   throw new Error('no copyrights was passed');
-  // }
-
-  if (!address) {
-    throw new Error('invalid address');
-  }
-  if (!unsubscribe) {
-    throw new Error('invalid unsubscribe');
-  }
-  
-  // if (typeof address != 'function'){
-  //   throw new Error('invalid invalid address, must be a function');
-  // }
-
-  // if (typeof unsubscribe != 'function') {
-  //   throw new Error('invalid unsubscribe, must be a function');
-  // }
-
-  if (!sponsor) {
-    throw new Error('invalid newsletterSponsorshipLink');
-  }
-  // if (typeof newsletterSponsorshipLink != 'function'){
-  //   throw new Error('invalid newsletterSponsorshipLink, must be a function');
-  // }
 
   return `<tr>
     <td
@@ -58,7 +28,30 @@ const renderCustomBlock = (params) => {
 };
 
 const footerComponent = ( params ) => {
-  const { address, sponsor, copyright, unsubscribe } = params;
+  validateInput(params, [
+    {
+      field: 'copyright',
+      errorMessage: 'no copyright was passed in footer component',
+      rules: ['required', 'nonEmptyString'],
+    },
+    {
+      field: 'address',
+      errorMessage: 'no address was passed',
+      rules: ['required', 'nonEmptyString'],
+    },
+    {
+      field: 'unsubscribe',
+      errorMessage: 'no unsubscribe was passed',
+      rules: ['required', 'nonEmptyString'],
+    },
+    {
+      field: 'sponsor',
+      errorMessage: 'no newsletterSponsorshipLink was passed',
+      rules: ['required', 'nonEmptyString'],
+    },
+  ]);
+
+  const { address, sponsor, copyright, unsubscribe } = params || {};
 
   // const {
   //   copyrightsComponent,
@@ -66,11 +59,6 @@ const footerComponent = ( params ) => {
   //   unsubscribeComponent,
   //   // newsletterSponsorshipLinkComponent
   // } = subcomponents;
-
-  if (!copyright) throw new Error('no copyright was passed in footer component');
-  if (!address) throw new Error('no address was passed');
-  if (!unsubscribe) throw new Error('no unsubscribe was passed');
-  if (!sponsor) throw new Error('no newsletterSponsorshipLink was passed');
 
   // console.log(copyright)
 

--- a/Work/src/components/headComponent.js
+++ b/Work/src/components/headComponent.js
@@ -1,17 +1,25 @@
-const headComponent = (params) => {
+import { validateInput } from './validation/validateInput';
+
+const headComponent = (params = {}) => {
+  validateInput(params, [
+    {
+      field: 'title',
+      errorMessage: 'no title was passed',
+      rules: ['required', 'nonEmptyString'],
+    },
+    {
+      field: 'headStyles',
+      errorMessage: 'no headStyles was passed',
+      rules: ['required', 'nonEmptyString'],
+    },
+    {
+      field: 'fonts',
+      errorMessage: 'no fonts was passed',
+      rules: ['required', 'nonEmptyString'],
+    },
+  ]);
+
   const { title, headStyles, fonts } = params;
-
-  if (!title) {
-    throw new Error('no title was passed');
-  }
-
-  if (!headStyles) {
-    throw new Error('no headStyles was passed');
-  }
-
-  if (!fonts) {
-    throw new Error('no fonts was passed');
-  }
 
   return `<head>
   <!-- NAME: 1 COLUMN -->

--- a/Work/src/components/mainComponent.js
+++ b/Work/src/components/mainComponent.js
@@ -1,3 +1,5 @@
+import { validateInput } from './validation/validateInput';
+
 const mainComponent = (params) => {
   if (!params) {
     throw new Error('no Sub Components was passed');
@@ -6,13 +8,18 @@ const mainComponent = (params) => {
   // TODO make it better
   const { head, body } = params;
 
-  if (!head || typeof head !== 'string') {
-    throw new Error('no head was passed');
-  }
-
-  if (!body || typeof body !== 'string') {
-    throw new Error('no body was passed');
-  }
+  validateInput(params, [
+    {
+      field: 'head',
+      errorMessage: 'no head was passed',
+      rules: ['required', 'string', 'nonEmptyString'],
+    },
+    {
+      field: 'body',
+      errorMessage: 'no body was passed',
+      rules: ['required', 'string', 'nonEmptyString'],
+    },
+  ]);
 
   // headComponent.isError();
   // bodyComponent.isError();

--- a/Work/src/components/previewText.js
+++ b/Work/src/components/previewText.js
@@ -1,14 +1,24 @@
-//const ERROR_PREVIEW = '`previewText` is a required option for `renderTemplate`';
-const checkingPreviewText = (previewText) => {
-  if (!previewText) {
-    throw new Error('`previewText` is a required option for `renderTemplate`');
-  }
+import { validateInput } from './validation/validateInput';
+
+// const ERROR_PREVIEW = '`previewText` is a required option for `renderTemplate`';
+export const checkingPreviewText = (previewText) => {
+  validateInput({ previewText }, [
+    {
+      field: 'previewText',
+      errorMessage: '`previewText` is a required option for `renderTemplate`',
+      rules: ['required', 'nonEmptyString'],
+    },
+  ]);
 };
 
 const previewTextComponent = (content) => {
-  if (!content) {
-    throw new Error('invalid preview text');
-  }
+  validateInput({ content }, [
+    {
+      field: 'content',
+      errorMessage: 'invalid preview text',
+      rules: ['required', 'nonEmptyString'],
+    },
+  ]);
 
   return `<!--[if !gte mso 9]><!---->
     ${content}

--- a/Work/src/components/validation/rules.js
+++ b/Work/src/components/validation/rules.js
@@ -1,0 +1,31 @@
+/**
+ * Reusable validation rules for legacy component rendering inputs.
+ *
+ * Rule contract:
+ * - return `null` when value passes validation
+ * - return a short reason string when value fails
+ */
+
+export const required = (value) => {
+  if (value === undefined || value === null) {
+    return 'is required';
+  }
+  return null;
+};
+
+export const nonEmptyString = (value) => {
+  if (value === '') {
+    return 'must not be empty';
+  }
+  return null;
+};
+
+export const string = (value) => {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== 'string') {
+    return 'must be a string';
+  }
+  return null;
+};

--- a/Work/src/components/validation/validateInput.js
+++ b/Work/src/components/validation/validateInput.js
@@ -1,0 +1,37 @@
+import { required, nonEmptyString, string } from './rules';
+
+const RULES = {
+  required,
+  nonEmptyString,
+  string,
+};
+
+/**
+ * Validate a list of fields and throw mapped errors on first failure.
+ *
+ * @param {object} input
+ * @param {Array<{
+ *  field: string,
+ *  errorMessage: string,
+ *  rules?: string[]
+ * }>} checks
+ */
+export const validateInput = (input, checks) => {
+  const normalized = input || {};
+
+  for (const check of checks) {
+    const fieldRules = check.rules || ['required', 'nonEmptyString'];
+    const value = normalized[check.field];
+
+    for (const ruleName of fieldRules) {
+      const rule = RULES[ruleName];
+      if (!rule) {
+        throw new Error(`Unknown validation rule: ${ruleName}`);
+      }
+
+      if (rule(value) !== null) {
+        throw new Error(check.errorMessage);
+      }
+    }
+  }
+};

--- a/Work/tests/unit/componentValidation.unit.test.js
+++ b/Work/tests/unit/componentValidation.unit.test.js
@@ -1,0 +1,61 @@
+import { required, nonEmptyString, string } from '../../src/components/validation/rules';
+import { validateInput } from '../../src/components/validation/validateInput';
+
+describe('components validation rules', () => {
+  test('required returns reason for undefined/null and null otherwise', () => {
+    expect(required(undefined)).toBe('is required');
+    expect(required(null)).toBe('is required');
+    expect(required('')).toBeNull();
+    expect(required(false)).toBeNull();
+  });
+
+  test('nonEmptyString returns reason only for empty string', () => {
+    expect(nonEmptyString('')).toBe('must not be empty');
+    expect(nonEmptyString('value')).toBeNull();
+    expect(nonEmptyString(undefined)).toBeNull();
+    expect(nonEmptyString(42)).toBeNull();
+  });
+
+  test('string returns reason for non-string values', () => {
+    expect(string('ok')).toBeNull();
+    expect(string(undefined)).toBeNull();
+    expect(string(null)).toBeNull();
+    expect(string(123)).toBe('must be a string');
+    expect(string({})).toBe('must be a string');
+  });
+});
+
+describe('validateInput (components)', () => {
+  test('passes when all checks pass', () => {
+    expect(() =>
+      validateInput(
+        { head: '<head></head>', body: '<body></body>' },
+        [
+          { field: 'head', errorMessage: 'head missing', rules: ['required', 'string', 'nonEmptyString'] },
+          { field: 'body', errorMessage: 'body missing', rules: ['required', 'string', 'nonEmptyString'] },
+        ]
+      )
+    ).not.toThrow();
+  });
+
+  test('throws mapped message on first failing field', () => {
+    expect(() =>
+      validateInput(
+        { head: '', body: '<body></body>' },
+        [
+          { field: 'head', errorMessage: 'head missing', rules: ['required', 'string', 'nonEmptyString'] },
+          { field: 'body', errorMessage: 'body missing', rules: ['required', 'string', 'nonEmptyString'] },
+        ]
+      )
+    ).toThrow('head missing');
+  });
+
+  test('uses default rules when rules omitted', () => {
+    expect(() =>
+      validateInput(
+        { title: '' },
+        [{ field: 'title', errorMessage: 'title required' }]
+      )
+    ).toThrow('title required');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add reusable component validation rules in `Work/src/components/validation/rules.js`
- add shared validator helper in `Work/src/components/validation/validateInput.js`
- refactor component input checks to use shared validation in:
  - `Work/src/components/body.js`
  - `Work/src/components/footer.js`
  - `Work/src/components/headComponent.js`
  - `Work/src/components/mainComponent.js`
  - `Work/src/components/previewText.js`
- preserve existing error message behavior expected by current tests
- add unit tests for the new validator: `Work/tests/unit/componentValidation.unit.test.js`

## Validation run
Executed targeted unit tests for affected components and validator:
- `tests/unit/body.unit.test.js`
- `tests/unit/footer.unit.test.js`
- `tests/unit/headComponent.unit.test.js`
- `tests/unit/headStyles.unit.test.js`
- `tests/unit/mainComponent.unit.test.js`
- `tests/unit/previewText.unit.test.js`
- `tests/unit/componentValidation.unit.test.js`

All passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ba175c5-e994-4dd1-bbbf-45a0c6bfe105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ba175c5-e994-4dd1-bbbf-45a0c6bfe105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

