### PR TITLE
Phase 3: start separating display engine from template content

### DIFF
--- a/Work/src/engine/display/index.js
+++ b/Work/src/engine/display/index.js
@@ -1,0 +1,4 @@
+export {
+  renderDisplayTemplate,
+  renderDisplayFrontMatterTemplate,
+} from './renderers';

--- a/Work/src/engine/display/renderers.js
+++ b/Work/src/engine/display/renderers.js
@@ -1,0 +1,33 @@
+import { displayFactoryTwo } from 'email-template-object';
+import { previewTextComponent } from '../../components';
+import { settings as headSettings } from '../../display/sections/head';
+import { settings as bodySettings } from '../../display/sections/body';
+import { settings as mainSettings } from '../../display/sections/main';
+
+export const renderDisplayTemplate = (generatedContent) => {
+  // Keep legacy mutation semantics for backward compatibility.
+  const bodyFactory = new displayFactoryTwo();
+  bodySettings.params.content = generatedContent;
+  const bodyHTMLString = bodyFactory.create(bodySettings);
+
+  const mainFactory = new displayFactoryTwo();
+  mainSettings.params.body = bodyHTMLString;
+  return mainFactory.create(mainSettings);
+};
+
+export const renderDisplayFrontMatterTemplate = ({ string: generatedContent, data }) => {
+  // Keep legacy mutation semantics for backward compatibility.
+  const headFactory = new displayFactoryTwo();
+  headSettings.params.title = data.title;
+  const headHTMLString = headFactory.create(headSettings);
+
+  const bodyFactory = new displayFactoryTwo();
+  bodySettings.params.content = generatedContent;
+  bodySettings.params.previewText = previewTextComponent(data.preview);
+  const bodyHTMLString = bodyFactory.create(bodySettings);
+
+  const mainFactory = new displayFactoryTwo();
+  mainSettings.params.head = headHTMLString;
+  mainSettings.params.body = bodyHTMLString;
+  return mainFactory.create(mainSettings);
+};

--- a/Work/src/t/displayFrontMatterTemplate.js
+++ b/Work/src/t/displayFrontMatterTemplate.js
@@ -1,56 +1,7 @@
-import { displayFactoryTwo } from 'email-template-object';
+import { renderDisplayFrontMatterTemplate } from '../engine/display';
 
-// import MainComponent from '../components/mainComponent';
-import {
-  
-    previewTextComponent
-} from '../components';
-
-import { settings as headSettings } from '../display/sections/head';
-
-import { 
-    settings as bodySettings
- } from '../display/sections/body';
-
- import {
-    settings as mainSettings
- } from '../display/sections/main';
-
-
-// title must be passed from the outside
-// const title = `The Secrets of High-Performing DevOps teams`;
-//     const head = displayHead(title);
-
-function displayFrontMatterTemplate({ string: generatedContent, data }) {
-
-    const HeadFactory = new displayFactoryTwo();
-    headSettings.params.title = data.title;
-    const HeadHTMLString = HeadFactory.create(headSettings);
-
-    // ----------------
-    const BodyFactory = new displayFactoryTwo();
-
-    bodySettings.params.content = generatedContent;
-    bodySettings.params.previewText = previewTextComponent(data.preview);  
-
-    const BodyHTMLString = BodyFactory.create(bodySettings);
-    // -------------
-    // console.log(BodyHTMLString)
-    // ------
-
-    const MainFactory = new displayFactoryTwo();
-
-    mainSettings.params.head = HeadHTMLString;
-    mainSettings.params.body = BodyHTMLString;
-
-    let MainHTMLString = MainFactory.create(mainSettings);
-
-
-
-    return MainHTMLString;
-
-
-};
-
+function displayFrontMatterTemplate(payload) {
+    return renderDisplayFrontMatterTemplate(payload);
+}
 
 export default displayFrontMatterTemplate;

--- a/Work/src/t/displayTemplate.js
+++ b/Work/src/t/displayTemplate.js
@@ -1,53 +1,7 @@
-import { displayFactoryTwo } from 'email-template-object';
-
-// import MainComponent from '../components/mainComponent';
-
-// import headString from '../display/displayHead';
-
-
-import { 
-    settings as bodySettings
- } from '../display/sections/body';
-
- import {
-    settings as mainSettings
- } from '../display/sections/main';
-
-
-// title must be passed from the outside
-// const title = `The Secrets of High-Performing DevOps teams`;
-//     const head = displayHead(title);
+import { renderDisplayTemplate } from '../engine/display';
 
 function displayTemplate(generatedContent) {
-
-
-    const BodyFactory = new displayFactoryTwo();
-
-    bodySettings.params.content = generatedContent;
-
-
-    const BodyHTMLString = BodyFactory.create(bodySettings);
-    
-    // console.log(BodyHTMLString)
-    // ------
-
-    const MainFactory = new displayFactoryTwo();
-
-    mainSettings.params.body = BodyHTMLString;
-
-    let MainHTMLString = MainFactory.create(mainSettings);
-
-    // console.log(MainHTMLString)
-
-    return MainHTMLString;
-
-    // const TemplateFactory = new displayFactoryTwo();
-// let Template = TemplateFactory.create(settings);
-// console.log(TemplateFactory.create(settings));
-// export default Template;
-
-
-};
-
+  return renderDisplayTemplate(generatedContent);
+}
 
 export default displayTemplate;

--- a/Work/src/templates/hn.js
+++ b/Work/src/templates/hn.js
@@ -1,5 +1,7 @@
-import displayTemplate from '../t/displayTemplate';
-import displayFrontMatterTemplate from '../t/displayFrontMatterTemplate';
+import {
+  renderDisplayTemplate,
+  renderDisplayFrontMatterTemplate,
+} from '../engine/display';
 
 /**
  * HN (Hacker News digest) email template.
@@ -18,9 +20,9 @@ const hnTemplate = {
         // front-matter fields (title, preview, …).  A plain string means
         // simple content-only rendering.
         if (data && typeof data === 'object' && data.data !== undefined) {
-            return displayFrontMatterTemplate(data);
+            return renderDisplayFrontMatterTemplate(data);
         }
-        return displayTemplate(data);
+        return renderDisplayTemplate(data);
     },
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- started Phase 3 by moving template display orchestration into a dedicated engine layer under `Work/src/engine/display/`
- added engine display renderers:
  - `renderDisplayTemplate`
  - `renderDisplayFrontMatterTemplate`
- updated `Work/src/templates/hn.js` to use engine display renderers instead of importing from `src/t/*`
- kept `src/t/displayTemplate.js` and `src/t/displayFrontMatterTemplate.js` as compatibility wrappers delegating to the new engine functions
- preserved legacy output behavior by keeping compatibility semantics in the new engine renderer flow

## Validation
- `npx jest ./tests/unit/templateBehavior.freeze.unit.test.js --passWithNoTests`
- `npx jest ./tests/unit/ ./tests/integration/ --passWithNoTests`
- Result: **32 passed, 0 failed** (356 tests, 2 snapshots)

## Why this is Phase 3-safe
- engine now owns display orchestration logic
- template content (`templates/hn`) imports engine, not legacy `t` internals
- compatibility wrappers keep existing callers stable while enabling further incremental extraction
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ba175c5-e994-4dd1-bbbf-45a0c6bfe105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ba175c5-e994-4dd1-bbbf-45a0c6bfe105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

