### PR TITLE
Add hn-without-ads template copy

### DIFF
--- a/Work/src/templates/hn-without-ads.js
+++ b/Work/src/templates/hn-without-ads.js
@@ -1,0 +1,29 @@
+import {
+  renderDisplayTemplate,
+  renderDisplayFrontMatterTemplate,
+} from '../engine/display';
+
+/**
+ * HN (Hacker News digest) email template (without ads variant).
+ *
+ * - Pass a plain string as `data` to render simple content.
+ * - Pass `{ string, data }` (with a `data.title` / `data.preview`) to render
+ *   the full front-matter variant.
+ *
+ * @type {import('./types').Template}
+ */
+const hnWithoutAdsTemplate = {
+  id: 'hn-without-ads',
+
+  render: (data) => {
+    // When `data` is `{ string, data }` the nested `data` property carries
+    // front-matter fields (title, preview, …). A plain string means
+    // simple content-only rendering.
+    if (data && typeof data === 'object' && data.data !== undefined) {
+      return renderDisplayFrontMatterTemplate(data);
+    }
+    return renderDisplayTemplate(data);
+  },
+};
+
+export default hnWithoutAdsTemplate;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- added a new template file: `Work/src/templates/hn-without-ads.js`
- this file is a direct copy of `Work/src/templates/hn.js`, as requested

## Validation
- `npx jest ./tests/unit/ ./tests/integration/ --passWithNoTests`
- Result: **32 passed, 0 failed** (356 tests, 2 snapshots)

## Notes
- no existing template behavior was modified in this change
- this is an additive template file for future wiring/use
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ba175c5-e994-4dd1-bbbf-45a0c6bfe105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ba175c5-e994-4dd1-bbbf-45a0c6bfe105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

