### PR TITLE
Phase 1: introduce template definitions for hn templates

### DIFF
--- a/Work/src/templates/definitions/createTemplateFromDefinition.js
+++ b/Work/src/templates/definitions/createTemplateFromDefinition.js
@@ -1,0 +1,32 @@
+/**
+ * Build a renderable template from a declarative template definition.
+ *
+ * @param {object} definition
+ * @param {string} definition.id
+ * @param {function(*): {variant: string, payload: *}} [definition.mapData]
+ * @param {Object.<string, function(*): string>} definition.renderers
+ * @returns {{ id: string, render: function(*): string }}
+ */
+export const createTemplateFromDefinition = (definition) => {
+  const {
+    id,
+    mapData = (input) => ({ variant: 'simple', payload: input }),
+    renderers,
+  } = definition;
+
+  return {
+    id,
+    render: (input) => {
+      const { variant, payload } = mapData(input);
+      const renderer = renderers[variant];
+
+      if (typeof renderer !== 'function') {
+        throw new Error(
+          `[template:${id}] unsupported render variant: ${variant}`
+        );
+      }
+
+      return renderer(payload);
+    },
+  };
+};

--- a/Work/src/templates/definitions/hn-without-ads.definition.js
+++ b/Work/src/templates/definitions/hn-without-ads.definition.js
@@ -1,0 +1,36 @@
+import {
+  renderDisplayTemplate,
+  renderDisplayFrontMatterTemplate,
+} from '../../engine/display';
+
+/**
+ * Declarative definition for the `hn-without-ads` template.
+ *
+ * Phase 1 introduces metadata + mapData while keeping existing rendering
+ * behavior unchanged.
+ */
+const hnWithoutAdsDefinition = {
+  id: 'hn-without-ads',
+  sections: {
+    head: 'displayHead',
+    body: 'displayBody',
+    footer: 'displayFooter',
+    main: 'displayMain',
+  },
+  featureFlags: {
+    ads: false,
+    blocks: ['hero', 'image-grid'],
+  },
+  mapData: (input) => {
+    if (input && typeof input === 'object' && input.data !== undefined) {
+      return { variant: 'frontMatter', payload: input };
+    }
+    return { variant: 'simple', payload: input };
+  },
+  renderers: {
+    simple: renderDisplayTemplate,
+    frontMatter: renderDisplayFrontMatterTemplate,
+  },
+};
+
+export default hnWithoutAdsDefinition;

--- a/Work/src/templates/definitions/hn.definition.js
+++ b/Work/src/templates/definitions/hn.definition.js
@@ -1,0 +1,36 @@
+import {
+  renderDisplayTemplate,
+  renderDisplayFrontMatterTemplate,
+} from '../../engine/display';
+
+/**
+ * Declarative definition for the `hn` template.
+ *
+ * Phase 1 keeps behavior parity while moving template configuration into
+ * first-class definition files.
+ */
+const hnDefinition = {
+  id: 'hn',
+  sections: {
+    head: 'displayHead',
+    body: 'displayBody',
+    footer: 'displayFooter',
+    main: 'displayMain',
+  },
+  featureFlags: {
+    ads: true,
+    blocks: ['hero', 'ads', 'image-grid'],
+  },
+  renderers: {
+    simple: renderDisplayTemplate,
+    frontMatter: renderDisplayFrontMatterTemplate,
+  },
+  mapData: (input) => {
+    if (input && typeof input === 'object' && input.data !== undefined) {
+      return { variant: 'frontMatter', payload: input };
+    }
+    return { variant: 'simple', payload: input };
+  },
+};
+
+export default hnDefinition;

--- a/Work/src/templates/definitions/index.js
+++ b/Work/src/templates/definitions/index.js
@@ -1,0 +1,3 @@
+export { createTemplateFromDefinition } from './createTemplateFromDefinition';
+export { default as hnDefinition } from './hn.definition';
+export { default as hnWithoutAdsDefinition } from './hn-without-ads.definition';

--- a/Work/src/templates/hn-without-ads.js
+++ b/Work/src/templates/hn-without-ads.js
@@ -1,7 +1,7 @@
 import {
-  renderDisplayTemplate,
-  renderDisplayFrontMatterTemplate,
-} from '../engine/display';
+  createTemplateFromDefinition,
+  hnWithoutAdsDefinition,
+} from './definitions';
 
 /**
  * HN (Hacker News digest) email template (without ads variant).
@@ -12,18 +12,8 @@ import {
  *
  * @type {import('./types').Template}
  */
-const hnWithoutAdsTemplate = {
-  id: 'hn-without-ads',
-
-  render: (data) => {
-    // When `data` is `{ string, data }` the nested `data` property carries
-    // front-matter fields (title, preview, …). A plain string means
-    // simple content-only rendering.
-    if (data && typeof data === 'object' && data.data !== undefined) {
-      return renderDisplayFrontMatterTemplate(data);
-    }
-    return renderDisplayTemplate(data);
-  },
-};
+const hnWithoutAdsTemplate = createTemplateFromDefinition(
+  hnWithoutAdsDefinition
+);
 
 export default hnWithoutAdsTemplate;

--- a/Work/src/templates/hn.js
+++ b/Work/src/templates/hn.js
@@ -1,7 +1,5 @@
-import {
-  renderDisplayTemplate,
-  renderDisplayFrontMatterTemplate,
-} from '../engine/display';
+import { createTemplateFromDefinition } from './definitions/createTemplateFromDefinition';
+import hnDefinition from './definitions/hn.definition';
 
 /**
  * HN (Hacker News digest) email template.
@@ -12,18 +10,6 @@ import {
  *
  * @type {import('./types').Template}
  */
-const hnTemplate = {
-    id: 'hn',
-
-    render: (data) => {
-        // When `data` is `{ string, data }` the nested `data` property carries
-        // front-matter fields (title, preview, …).  A plain string means
-        // simple content-only rendering.
-        if (data && typeof data === 'object' && data.data !== undefined) {
-            return renderDisplayFrontMatterTemplate(data);
-        }
-        return renderDisplayTemplate(data);
-    },
-};
+const hnTemplate = createTemplateFromDefinition(hnDefinition);
 
 export default hnTemplate;

--- a/Work/tests/unit/templateDefinitions.unit.test.js
+++ b/Work/tests/unit/templateDefinitions.unit.test.js
@@ -1,0 +1,83 @@
+jest.mock('atherdon-newsletter-js-layouts-misc', () => ({
+  __esModule: true,
+  default: {
+    fontsComponent: () => '<fonts-component />',
+    addressComponent: ({ mailingAddress }) => `<address>${mailingAddress}</address>`,
+    copyrightsComponent: () => '<copyrights-component />',
+    newsletterSponsorshipLinkComponent: ({ contact }) => `<sponsor>${contact}</sponsor>`,
+    unsubscribeComponent: ({ unsubscribeLink }) => `<unsubscribe>${unsubscribeLink}</unsubscribe>`,
+  },
+}), { virtual: true });
+
+jest.mock('atherdon-newsletter-js-layouts-body', () => ({
+  __esModule: true,
+  default: {
+    logoTopComponent: () => '<logo-top-component />',
+    logoBottomComponent: () => '<logo-bottom-component />',
+  },
+}), { virtual: true });
+
+const { createTemplateFromDefinition } = require('../../src/templates/definitions');
+const {
+  hnDefinition,
+  hnWithoutAdsDefinition,
+} = require('../../src/templates/definitions');
+
+describe('template definitions', () => {
+  test('hn definition has expected metadata and maps plain string to simple variant', () => {
+    const mapped = hnDefinition.mapData('<p>Hello</p>');
+    expect(hnDefinition.id).toBe('hn');
+    expect(hnDefinition.sections).toEqual({
+      head: 'displayHead',
+      body: 'displayBody',
+      footer: 'displayFooter',
+      main: 'displayMain',
+    });
+    expect(mapped).toEqual({
+      variant: 'simple',
+      payload: '<p>Hello</p>',
+    });
+  });
+
+  test('hn definition maps front-matter payload to frontMatter variant', () => {
+    const payload = { string: '<p>x</p>', data: { title: 'Title' } };
+    expect(hnDefinition.mapData(payload)).toEqual({
+      variant: 'frontMatter',
+      payload,
+    });
+  });
+
+  test('hn-without-ads definition exposes expected metadata', () => {
+    expect(hnWithoutAdsDefinition.id).toBe('hn-without-ads');
+    expect(hnWithoutAdsDefinition.featureFlags.ads).toBe(false);
+    expect(hnWithoutAdsDefinition.sections.main).toBe('displayMain');
+  });
+});
+
+describe('createTemplateFromDefinition', () => {
+  test('routes payloads to correct renderer variant', () => {
+    const template = createTemplateFromDefinition({
+      id: 'demo',
+      mapData: (input) => input,
+      renderers: {
+        simple: (payload) => `simple:${payload}`,
+        frontMatter: (payload) => `front:${payload.value}`,
+      },
+    });
+
+    expect(template.render({ variant: 'simple', payload: 'x' })).toBe('simple:x');
+    expect(template.render({ variant: 'frontMatter', payload: { value: 'y' } })).toBe('front:y');
+  });
+
+  test('throws a clear error for unsupported variants', () => {
+    const template = createTemplateFromDefinition({
+      id: 'demo',
+      mapData: () => ({ variant: 'missing', payload: {} }),
+      renderers: {},
+    });
+
+    expect(() => template.render({})).toThrow(
+      '[template:demo] unsupported render variant: missing'
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **Phase 1:** introduce template definitions and migrate `hn`/`hn-without-ads` template construction to definition-based adapters
  - add `Work/src/templates/definitions/`
    - `createTemplateFromDefinition.js`
    - `hn.definition.js`
    - `hn-without-ads.definition.js`
    - `index.js`
  - update:
    - `Work/src/templates/hn.js`
    - `Work/src/templates/hn-without-ads.js`
  - add unit coverage:
    - `Work/tests/unit/templateDefinitions.unit.test.js`
- **Phase 2:** make display renderers pure/non-mutating
  - refactor `Work/src/engine/display/renderers.js` to build per-call cloned settings instead of mutating imported shared `settings` objects
  - add non-mutation coverage:
    - `Work/tests/unit/displayRenderers.pure.unit.test.js`
- update documentation to reflect Phase 1 and Phase 2 progress:
  - `Work/README.md`
- update freeze snapshot to deterministic output under pure renderer semantics:
  - `Work/tests/unit/__snapshots__/templateBehavior.freeze.unit.test.js.snap`

## Validation
- `npm run test:unit -- displayRenderers.pure.unit.test.js templateDefinitions.unit.test.js templates.unit.test.js templateEngine.contract.unit.test.js templateBehavior.freeze.unit.test.js`
  - all suites passed (23/23)

## Notes
- output contracts are preserved, but renderer internals are now side-effect free and deterministic.
- snapshot update is expected because previous snapshot captured state leakage from renderer mutations.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80b857f0-6772-4e4f-a6fa-8ab745641325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80b857f0-6772-4e4f-a6fa-8ab745641325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

