### PR TITLE
Step 2 modularization: extract HN preset definitions package

### DIFF
--- a/Work/README.md
+++ b/Work/README.md
@@ -195,6 +195,27 @@ Workspace wiring updates:
 - `Work/package.json` now includes `../packages/template-engine` in workspaces
 - `Work/package.json` now depends on `@llazyemail/template-engine`
 
+### Module split — Step 2 (extract `template-presets-hn` package)
+
+Moved HN preset metadata/mapping into a dedicated workspace package:
+
+- `packages/template-presets-hn/`
+  - `src/hnPreset.js`
+  - `src/hnWithoutAdsPreset.js`
+  - `src/index.js`
+
+`Work` keeps the same public behavior by composing runtime adapters
+(display renderers + validation hooks) on top of those preset exports:
+
+- `src/templates/definitions/hn-preset-adapters.js`
+- `src/templates/definitions/hn.definition.js` (wrapper export)
+- `src/templates/definitions/hn-without-ads.definition.js` (wrapper export)
+
+Workspace wiring updates:
+
+- `Work/package.json` now includes `../packages/template-presets-hn` in workspaces
+- `Work/package.json` now depends on `@llazyemail/template-presets-hn`
+
 ## Structure
 
 ```

--- a/Work/package-lock.json
+++ b/Work/package-lock.json
@@ -10,12 +10,14 @@
       "license": "MIT",
       "workspaces": [
         "../packages/template-engine",
+        "../packages/template-presets-hn",
         "../sub-modules/Typography",
         "../sub-modules/innerComponents",
         "../sub-modules/Miscellaneous"
       ],
       "dependencies": {
         "@llazyemail/template-engine": "0.1.0",
+        "@llazyemail/template-presets-hn": "0.1.0",
         "atherdon-newsletter-js-layouts-body": "^3.2.0",
         "atherdon-newsletter-js-layouts-misc": "^3.0.0",
         "atherdon-newsletter-js-layouts-typography": "^3.1.0",
@@ -58,6 +60,11 @@
     },
     "../packages/template-engine": {
       "name": "@llazyemail/template-engine",
+      "version": "0.1.0",
+      "license": "MIT"
+    },
+    "../packages/template-presets-hn": {
+      "name": "@llazyemail/template-presets-hn",
       "version": "0.1.0",
       "license": "MIT"
     },
@@ -2971,6 +2978,10 @@
     },
     "node_modules/@llazyemail/template-engine": {
       "resolved": "../packages/template-engine",
+      "link": true
+    },
+    "node_modules/@llazyemail/template-presets-hn": {
+      "resolved": "../packages/template-presets-hn",
       "link": true
     },
     "node_modules/@manypkg/find-root": {
@@ -13189,6 +13200,9 @@
     },
     "@llazyemail/template-engine": {
       "version": "file:../packages/template-engine"
+    },
+    "@llazyemail/template-presets-hn": {
+      "version": "file:../packages/template-presets-hn"
     },
     "@manypkg/find-root": {
       "version": "1.1.0",

--- a/Work/package.json
+++ b/Work/package.json
@@ -63,6 +63,7 @@
   "private": false,
   "workspaces": [
     "../packages/template-engine",
+    "../packages/template-presets-hn",
     "../sub-modules/Typography",
     "../sub-modules/innerComponents",
     "../sub-modules/Miscellaneous"
@@ -75,6 +76,7 @@
   },
   "dependencies": {
     "@llazyemail/template-engine": "0.1.0",
+    "@llazyemail/template-presets-hn": "0.1.0",
     "atherdon-newsletter-js-layouts-body": "^3.2.0",
     "atherdon-newsletter-js-layouts-misc": "^3.0.0",
     "atherdon-newsletter-js-layouts-typography": "^3.1.0",

--- a/Work/src/templates/definitions/hn-preset-adapters.js
+++ b/Work/src/templates/definitions/hn-preset-adapters.js
@@ -1,0 +1,43 @@
+import {
+  createHnPresetDefinition,
+  createHnWithoutAdsPresetDefinition,
+} from '@llazyemail/template-presets-hn';
+import {
+  renderDisplayTemplate,
+  renderDisplayFrontMatterTemplate,
+} from '../../engine/display';
+import {
+  validateHnTemplateInput,
+  validateHnWithoutAdsTemplateInput,
+} from './validation';
+
+const withRuntimeAdapters = (preset, { renderers, validateInput }) => ({
+  ...preset,
+  renderers,
+  validateInput,
+});
+
+export const buildHnDefinition = ({ renderers, validateInput } = {}) =>
+  withRuntimeAdapters(createHnPresetDefinition(), {
+    renderers: renderers || {
+      simple: renderDisplayTemplate,
+      frontMatter: renderDisplayFrontMatterTemplate,
+    },
+    validateInput: validateInput || validateHnTemplateInput,
+  });
+
+export const buildHnWithoutAdsDefinition = ({
+  renderers,
+  validateInput,
+} = {}) =>
+  withRuntimeAdapters(createHnWithoutAdsPresetDefinition(), {
+    renderers: renderers || {
+      simple: renderDisplayTemplate,
+      frontMatter: renderDisplayFrontMatterTemplate,
+    },
+    validateInput: validateInput || validateHnWithoutAdsTemplateInput,
+  });
+
+export const hnDefinition = buildHnDefinition();
+
+export const hnWithoutAdsDefinition = buildHnWithoutAdsDefinition();

--- a/Work/src/templates/definitions/hn-without-ads.definition.js
+++ b/Work/src/templates/definitions/hn-without-ads.definition.js
@@ -1,38 +1,3 @@
-import {
-  renderDisplayTemplate,
-  renderDisplayFrontMatterTemplate,
-} from '../../engine/display';
-import { validateHnWithoutAdsTemplateInput } from './validation';
-
-/**
- * Declarative definition for the `hn-without-ads` template.
- *
- * Phase 1 introduces metadata + mapData while keeping existing rendering
- * behavior unchanged.
- */
-const hnWithoutAdsDefinition = {
-  id: 'hn-without-ads',
-  sections: {
-    head: 'displayHead',
-    body: 'displayBody',
-    footer: 'displayFooter',
-    main: 'displayMain',
-  },
-  featureFlags: {
-    ads: false,
-    blocks: ['hero', 'image-grid'],
-  },
-  mapData: (input) => {
-    if (input && typeof input === 'object' && input.data !== undefined) {
-      return { variant: 'frontMatter', payload: input };
-    }
-    return { variant: 'simple', payload: input };
-  },
-  renderers: {
-    simple: renderDisplayTemplate,
-    frontMatter: renderDisplayFrontMatterTemplate,
-  },
-  validateInput: validateHnWithoutAdsTemplateInput,
-};
+import { hnWithoutAdsDefinition } from './hn-preset-adapters';
 
 export default hnWithoutAdsDefinition;

--- a/Work/src/templates/definitions/hn.definition.js
+++ b/Work/src/templates/definitions/hn.definition.js
@@ -1,38 +1,3 @@
-import {
-  renderDisplayTemplate,
-  renderDisplayFrontMatterTemplate,
-} from '../../engine/display';
-import { validateHnTemplateInput } from './validation';
-
-/**
- * Declarative definition for the `hn` template.
- *
- * Phase 1 keeps behavior parity while moving template configuration into
- * first-class definition files.
- */
-const hnDefinition = {
-  id: 'hn',
-  sections: {
-    head: 'displayHead',
-    body: 'displayBody',
-    footer: 'displayFooter',
-    main: 'displayMain',
-  },
-  featureFlags: {
-    ads: true,
-    blocks: ['hero', 'ads', 'image-grid'],
-  },
-  renderers: {
-    simple: renderDisplayTemplate,
-    frontMatter: renderDisplayFrontMatterTemplate,
-  },
-  mapData: (input) => {
-    if (input && typeof input === 'object' && input.data !== undefined) {
-      return { variant: 'frontMatter', payload: input };
-    }
-    return { variant: 'simple', payload: input };
-  },
-  validateInput: validateHnTemplateInput,
-};
+import { hnDefinition } from './hn-preset-adapters';
 
 export default hnDefinition;

--- a/Work/src/templates/definitions/index.js
+++ b/Work/src/templates/definitions/index.js
@@ -3,5 +3,4 @@ export {
   validateHnTemplateInput,
   validateHnWithoutAdsTemplateInput,
 } from './validation';
-export { default as hnDefinition } from './hn.definition';
-export { default as hnWithoutAdsDefinition } from './hn-without-ads.definition';
+export { hnDefinition, hnWithoutAdsDefinition } from './hn-preset-adapters';

--- a/packages/template-presets-hn/package.json
+++ b/packages/template-presets-hn/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@llazyemail/template-presets-hn",
+  "version": "0.1.0",
+  "private": true,
+  "description": "HN template preset definitions (metadata + payload mapping).",
+  "main": "src/index.js",
+  "license": "MIT"
+}

--- a/packages/template-presets-hn/src/hnPreset.js
+++ b/packages/template-presets-hn/src/hnPreset.js
@@ -1,0 +1,40 @@
+/**
+ * Render-agnostic metadata and mapping for the `hn` template.
+ *
+ * Renderer and validation wiring remain in Work for backward compatibility
+ * during modularization.
+ */
+export const mapHnInputToVariant = (input) => {
+  if (input && typeof input === 'object' && input.data !== undefined) {
+    return { variant: 'frontMatter', payload: input };
+  }
+  return { variant: 'simple', payload: input };
+};
+
+export const hnPreset = {
+  id: 'hn',
+  sections: {
+    head: 'displayHead',
+    body: 'displayBody',
+    footer: 'displayFooter',
+    main: 'displayMain',
+  },
+  featureFlags: {
+    ads: true,
+    blocks: ['hero', 'ads', 'image-grid'],
+  },
+  mapData: mapHnInputToVariant,
+};
+
+export const createHnPresetDefinition = ({
+  renderers = {},
+  validateInput = () => {},
+  mapData = mapHnInputToVariant,
+} = {}) => ({
+  ...hnPreset,
+  renderers,
+  validateInput,
+  mapData,
+});
+
+export default hnPreset;

--- a/packages/template-presets-hn/src/hnWithoutAdsPreset.js
+++ b/packages/template-presets-hn/src/hnWithoutAdsPreset.js
@@ -1,0 +1,28 @@
+export const mapHnWithoutAdsInputToVariant = (input) => {
+  if (input && typeof input === 'object' && input.data !== undefined) {
+    return { variant: 'frontMatter', payload: input };
+  }
+  return { variant: 'simple', payload: input };
+};
+
+export const hnWithoutAdsPreset = {
+  id: 'hn-without-ads',
+  sections: {
+    head: 'displayHead',
+    body: 'displayBody',
+    footer: 'displayFooter',
+    main: 'displayMain',
+  },
+  featureFlags: {
+    ads: false,
+    blocks: ['hero', 'image-grid'],
+  },
+  mapData: mapHnWithoutAdsInputToVariant,
+};
+
+export const createHnWithoutAdsPresetDefinition = (overrides = {}) => ({
+  ...hnWithoutAdsPreset,
+  ...overrides,
+});
+
+export default hnWithoutAdsPreset;

--- a/packages/template-presets-hn/src/index.js
+++ b/packages/template-presets-hn/src/index.js
@@ -1,0 +1,10 @@
+export {
+  mapHnInputToVariant,
+  createHnPresetDefinition,
+  hnPreset,
+} from './hnPreset';
+export {
+  mapHnWithoutAdsInputToVariant,
+  createHnWithoutAdsPresetDefinition,
+  hnWithoutAdsPreset,
+} from './hnWithoutAdsPreset';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements modularization **Step 2** by extracting HN preset definitions into a dedicated workspace package while preserving existing `Work` behavior.

### New workspace package
- `packages/template-presets-hn/package.json`
- `packages/template-presets-hn/src/hnPreset.js`
- `packages/template-presets-hn/src/hnWithoutAdsPreset.js`
- `packages/template-presets-hn/src/index.js`

This package is intentionally render-agnostic and contains only preset metadata + payload mapping.

### Work compatibility layer
`Work` now composes runtime adapters (display renderers + validation hooks) on top of imported presets:

- `Work/src/templates/definitions/hn-preset-adapters.js` (new)
- `Work/src/templates/definitions/hn.definition.js` (re-export from adapter)
- `Work/src/templates/definitions/hn-without-ads.definition.js` (re-export from adapter)
- `Work/src/templates/definitions/index.js` (exports from adapter)

### Workspace wiring
- `Work/package.json`
  - add workspace: `../packages/template-presets-hn`
  - add dependency: `@llazyemail/template-presets-hn`
- `Work/package-lock.json` updated via `npm install`

### Docs
- `Work/README.md`
  - add **Module split — Step 2** section documenting extracted preset package and compatibility approach

## Validation
- `npm run test:unit -- templateDefinitions.unit.test.js templateValidation.unit.test.js templates.unit.test.js templateEngine.contract.unit.test.js`
  - passed (24/24 suites)

## Scope
- step-2-only extraction of `hn` preset definitions
- no intended changes to template rendering output contracts or `Work` public API
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80b857f0-6772-4e4f-a6fa-8ab745641325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80b857f0-6772-4e4f-a6fa-8ab745641325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

