### PR TITLE
Step 3 modularization: extract display runtime package

### DIFF
--- a/Work/README.md
+++ b/Work/README.md
@@ -216,6 +216,24 @@ Workspace wiring updates:
 - `Work/package.json` now includes `../packages/template-presets-hn` in workspaces
 - `Work/package.json` now depends on `@llazyemail/template-presets-hn`
 
+### Module split — Step 3 (extract `template-runtime-display` package)
+
+Moved display runtime rendering helpers into a dedicated workspace package:
+
+- `packages/template-runtime-display/`
+  - `src/renderers.js`
+  - `src/index.js`
+
+`Work` keeps the same `engine/display` API by delegating to the runtime package:
+
+- `src/engine/display/renderers.js` now imports and re-exports runtime renderers
+  from `@llazyemail/template-runtime-display`
+
+Workspace wiring updates:
+
+- `Work/package.json` now includes `../packages/template-runtime-display` in workspaces
+- `Work/package.json` now depends on `@llazyemail/template-runtime-display`
+
 ## Structure
 
 ```

--- a/Work/package-lock.json
+++ b/Work/package-lock.json
@@ -11,6 +11,7 @@
       "workspaces": [
         "../packages/template-engine",
         "../packages/template-presets-hn",
+        "../packages/template-runtime-display",
         "../sub-modules/Typography",
         "../sub-modules/innerComponents",
         "../sub-modules/Miscellaneous"
@@ -18,6 +19,7 @@
       "dependencies": {
         "@llazyemail/template-engine": "0.1.0",
         "@llazyemail/template-presets-hn": "0.1.0",
+        "@llazyemail/template-runtime-display": "0.1.0",
         "atherdon-newsletter-js-layouts-body": "^3.2.0",
         "atherdon-newsletter-js-layouts-misc": "^3.0.0",
         "atherdon-newsletter-js-layouts-typography": "^3.1.0",
@@ -65,6 +67,11 @@
     },
     "../packages/template-presets-hn": {
       "name": "@llazyemail/template-presets-hn",
+      "version": "0.1.0",
+      "license": "MIT"
+    },
+    "../packages/template-runtime-display": {
+      "name": "@llazyemail/template-runtime-display",
       "version": "0.1.0",
       "license": "MIT"
     },
@@ -2982,6 +2989,10 @@
     },
     "node_modules/@llazyemail/template-presets-hn": {
       "resolved": "../packages/template-presets-hn",
+      "link": true
+    },
+    "node_modules/@llazyemail/template-runtime-display": {
+      "resolved": "../packages/template-runtime-display",
       "link": true
     },
     "node_modules/@manypkg/find-root": {
@@ -13203,6 +13214,9 @@
     },
     "@llazyemail/template-presets-hn": {
       "version": "file:../packages/template-presets-hn"
+    },
+    "@llazyemail/template-runtime-display": {
+      "version": "file:../packages/template-runtime-display"
     },
     "@manypkg/find-root": {
       "version": "1.1.0",

--- a/Work/package.json
+++ b/Work/package.json
@@ -64,6 +64,7 @@
   "workspaces": [
     "../packages/template-engine",
     "../packages/template-presets-hn",
+    "../packages/template-runtime-display",
     "../sub-modules/Typography",
     "../sub-modules/innerComponents",
     "../sub-modules/Miscellaneous"
@@ -77,6 +78,7 @@
   "dependencies": {
     "@llazyemail/template-engine": "0.1.0",
     "@llazyemail/template-presets-hn": "0.1.0",
+    "@llazyemail/template-runtime-display": "0.1.0",
     "atherdon-newsletter-js-layouts-body": "^3.2.0",
     "atherdon-newsletter-js-layouts-misc": "^3.0.0",
     "atherdon-newsletter-js-layouts-typography": "^3.1.0",

--- a/Work/src/engine/display/renderers.js
+++ b/Work/src/engine/display/renderers.js
@@ -3,50 +3,24 @@ import { previewTextComponent } from '../../components';
 import { settings as headSettings } from '../../display/sections/head';
 import { settings as bodySettings } from '../../display/sections/body';
 import { settings as mainSettings } from '../../display/sections/main';
+import {
+  createDisplayTemplateRenderer,
+  createDisplayFrontMatterRenderer,
+} from '@llazyemail/template-runtime-display';
 
-const createSettings = (baseSettings, paramsOverrides = {}) => ({
-  ...baseSettings,
-  params: {
-    ...baseSettings.params,
-    ...paramsOverrides,
-  },
+const createFactory = () => new displayFactoryTwo();
+
+export const renderDisplayTemplate = createDisplayTemplateRenderer({
+  createFactory,
+  bodySettings,
+  mainSettings,
 });
 
-export const renderDisplayTemplate = (generatedContent) => {
-  const bodyRenderSettings = createSettings(bodySettings, {
-    content: generatedContent,
+export const renderDisplayFrontMatterTemplate =
+  createDisplayFrontMatterRenderer({
+    createFactory,
+    previewTextComponent,
+    headSettings,
+    bodySettings,
+    mainSettings,
   });
-  const bodyFactory = new displayFactoryTwo();
-  const bodyHTMLString = bodyFactory.create(bodyRenderSettings);
-
-  const mainRenderSettings = createSettings(mainSettings, {
-    body: bodyHTMLString,
-  });
-  const mainFactory = new displayFactoryTwo();
-  return mainFactory.create(mainRenderSettings);
-};
-
-export const renderDisplayFrontMatterTemplate = ({
-  string: generatedContent,
-  data,
-}) => {
-  const headRenderSettings = createSettings(headSettings, {
-    title: data.title,
-  });
-  const headFactory = new displayFactoryTwo();
-  const headHTMLString = headFactory.create(headRenderSettings);
-
-  const bodyRenderSettings = createSettings(bodySettings, {
-    content: generatedContent,
-    previewText: previewTextComponent(data.preview),
-  });
-  const bodyFactory = new displayFactoryTwo();
-  const bodyHTMLString = bodyFactory.create(bodyRenderSettings);
-
-  const mainRenderSettings = createSettings(mainSettings, {
-    head: headHTMLString,
-    body: bodyHTMLString,
-  });
-  const mainFactory = new displayFactoryTwo();
-  return mainFactory.create(mainRenderSettings);
-};

--- a/packages/template-runtime-display/package.json
+++ b/packages/template-runtime-display/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@llazyemail/template-runtime-display",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Display runtime renderer helpers for HTML template composition.",
+  "main": "src/index.js",
+  "license": "MIT"
+}

--- a/packages/template-runtime-display/src/index.js
+++ b/packages/template-runtime-display/src/index.js
@@ -1,0 +1,6 @@
+export {
+  createSettings,
+  createDisplayTemplateRenderer,
+  createDisplayFrontMatterRenderer,
+  createDisplayRendererRuntime,
+} from './renderers';

--- a/packages/template-runtime-display/src/renderers.js
+++ b/packages/template-runtime-display/src/renderers.js
@@ -1,0 +1,77 @@
+export const createSettings = (baseSettings, paramsOverrides = {}) => ({
+  ...baseSettings,
+  params: {
+    ...baseSettings.params,
+    ...paramsOverrides,
+  },
+});
+
+/**
+ * Build the simple display template runtime.
+ *
+ * @param {object} deps
+ * @param {Function} deps.createFactory
+ * @param {object} deps.bodySettings
+ * @param {object} deps.mainSettings
+ * @returns {function(string): string}
+ */
+export const createDisplayTemplateRenderer = ({
+  createFactory,
+  bodySettings,
+  mainSettings,
+}) => {
+  return (generatedContent) => {
+    const bodyRenderSettings = createSettings(bodySettings, {
+      content: generatedContent,
+    });
+    const bodyFactory = createFactory();
+    const bodyHTMLString = bodyFactory.create(bodyRenderSettings);
+
+    const mainRenderSettings = createSettings(mainSettings, {
+      body: bodyHTMLString,
+    });
+    const mainFactory = createFactory();
+    return mainFactory.create(mainRenderSettings);
+  };
+};
+
+/**
+ * Build the front-matter display template runtime.
+ *
+ * @param {object} deps
+ * @param {Function} deps.createFactory
+ * @param {Function} deps.previewTextComponent
+ * @param {object} deps.headSettings
+ * @param {object} deps.bodySettings
+ * @param {object} deps.mainSettings
+ * @returns {function({string: string, data: object}): string}
+ */
+export const createDisplayFrontMatterRenderer = ({
+  createFactory,
+  previewTextComponent,
+  headSettings,
+  bodySettings,
+  mainSettings,
+}) => {
+  return ({ string: generatedContent, data }) => {
+    const headRenderSettings = createSettings(headSettings, {
+      title: data.title,
+    });
+    const headFactory = createFactory();
+    const headHTMLString = headFactory.create(headRenderSettings);
+
+    const bodyRenderSettings = createSettings(bodySettings, {
+      content: generatedContent,
+      previewText: previewTextComponent(data.preview),
+    });
+    const bodyFactory = createFactory();
+    const bodyHTMLString = bodyFactory.create(bodyRenderSettings);
+
+    const mainRenderSettings = createSettings(mainSettings, {
+      head: headHTMLString,
+      body: bodyHTMLString,
+    });
+    const mainFactory = createFactory();
+    return mainFactory.create(mainRenderSettings);
+  };
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements modularization **Step 3** by extracting display runtime renderer logic into a dedicated workspace package while preserving existing `Work` behavior.

### New workspace package
- `packages/template-runtime-display/package.json`
- `packages/template-runtime-display/src/renderers.js`
- `packages/template-runtime-display/src/index.js`

This package contains renderer runtime constructors and pure settings helpers:
- `createSettings`
- `createDisplayTemplateRenderer`
- `createDisplayFrontMatterRenderer`

### Work compatibility layer
`Work` keeps backward compatibility by composing runtime dependencies and exposing the same exported functions:

- `Work/src/engine/display/renderers.js`
  - now imports runtime constructors from `@llazyemail/template-runtime-display`
  - wires `displayFactoryTwo`, section settings, and `previewTextComponent`
  - continues exporting `renderDisplayTemplate` and `renderDisplayFrontMatterTemplate`

### Workspace wiring
- `Work/package.json`
  - add workspace: `../packages/template-runtime-display`
  - add dependency: `@llazyemail/template-runtime-display`
- `Work/package-lock.json` updated via `npm install`

### Docs
- `Work/README.md`
  - add **Module split — Step 3** section documenting extraction scope and compatibility approach

## Validation
- `npm run test:unit -- displayRenderers.pure.unit.test.js templateDefinitions.unit.test.js templateValidation.unit.test.js templates.unit.test.js templateEngine.contract.unit.test.js`
  - passed (24/24 suites)

## Scope
- step-3-only extraction of display runtime renderers
- no intended change to existing renderer output contracts or public API
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80b857f0-6772-4e4f-a6fa-8ab745641325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80b857f0-6772-4e4f-a6fa-8ab745641325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

