### PR TITLE
Add outerTemplate component folders and empty component exports

### DIFF
--- a/sub-modules/outerTemplate/README.md
+++ b/sub-modules/outerTemplate/README.md
@@ -14,20 +14,24 @@ outer-template extraction from `Work/`.
 `outerTemplate` is intentionally an **empty scaffold**:
 
 - has full package/tooling structure (`package.json`, `rollup.config.js`, `src/`, `tests/`)
-- exports an empty default object for now
+- has an initial component surface (`body`, `head`, `main`) plus a placeholder
+  `footer` component folder
 - can run basic build/test/lint commands
 
 ## Public API
 
 ```js
 import outerTemplate from 'atherdon-newsletter-js-layouts-outertemplate';
+
+const { bodyComponent, headComponent, mainComponent, footerComponent } = outerTemplate;
 ```
 
-Current export shape:
+Current component behavior:
 
-```js
-{}
-```
+- `bodyComponent()` returns an empty string (`''`)
+- `headComponent()` returns an empty string (`''`)
+- `mainComponent()` returns an empty string (`''`)
+- `footerComponent()` returns an empty string (`''`)
 
 ## Commands
 

--- a/sub-modules/outerTemplate/src/components.js
+++ b/sub-modules/outerTemplate/src/components.js
@@ -1,0 +1,13 @@
+import bodyComponent from './components/body';
+import headComponent from './components/head';
+import mainComponent from './components/main';
+import footerComponent from './components/footer';
+
+const outerTemplateComponents = {
+  bodyComponent,
+  headComponent,
+  mainComponent,
+  footerComponent,
+};
+
+export default outerTemplateComponents;

--- a/sub-modules/outerTemplate/src/components/body.js
+++ b/sub-modules/outerTemplate/src/components/body.js
@@ -1,0 +1,3 @@
+const bodyComponent = () => '';
+
+export default bodyComponent;

--- a/sub-modules/outerTemplate/src/components/footer/index.js
+++ b/sub-modules/outerTemplate/src/components/footer/index.js
@@ -1,0 +1,3 @@
+const footerComponent = () => '';
+
+export default footerComponent;

--- a/sub-modules/outerTemplate/src/components/head/index.js
+++ b/sub-modules/outerTemplate/src/components/head/index.js
@@ -1,0 +1,3 @@
+const headComponent = () => '';
+
+export default headComponent;

--- a/sub-modules/outerTemplate/src/components/main.js
+++ b/sub-modules/outerTemplate/src/components/main.js
@@ -1,0 +1,3 @@
+const mainComponent = () => '';
+
+export default mainComponent;

--- a/sub-modules/outerTemplate/src/index.js
+++ b/sub-modules/outerTemplate/src/index.js
@@ -1,3 +1,3 @@
-const outerTemplate = {};
+import outerTemplateComponents from './components';
 
-export default outerTemplate;
+export default outerTemplateComponents;

--- a/sub-modules/outerTemplate/tests/index.test.js
+++ b/sub-modules/outerTemplate/tests/index.test.js
@@ -1,8 +1,23 @@
 import outerTemplate from '../src/index';
 
 describe('outerTemplate scaffold', () => {
-  test('exports a plain object', () => {
+  test('exports component placeholders object', () => {
     expect(typeof outerTemplate).toBe('object');
     expect(outerTemplate).not.toBeNull();
+    expect(outerTemplate).toHaveProperty('bodyComponent');
+    expect(outerTemplate).toHaveProperty('headComponent');
+    expect(outerTemplate).toHaveProperty('mainComponent');
+    expect(outerTemplate).toHaveProperty('footerComponent');
+    expect(typeof outerTemplate.bodyComponent).toBe('function');
+    expect(typeof outerTemplate.headComponent).toBe('function');
+    expect(typeof outerTemplate.mainComponent).toBe('function');
+    expect(typeof outerTemplate.footerComponent).toBe('function');
+  });
+
+  test('placeholder components return empty strings', () => {
+    expect(outerTemplate.bodyComponent({})).toBe('');
+    expect(outerTemplate.headComponent({})).toBe('');
+    expect(outerTemplate.mainComponent({})).toBe('');
+    expect(outerTemplate.footerComponent({})).toBe('');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Requested scaffold updates for `sub-modules/outerTemplate`:

- create `src/components/` folder
- create nested folders:
  - `src/components/footer/`
  - `src/components/head/`
- add empty component placeholders keeping existing sub-module export style:
  - `src/components/body.js`
  - `src/components/head/index.js`
  - `src/components/main.js`
  - `src/components/footer/index.js`
- add `src/components.js` aggregator object
- update `src/index.js` to export components object (same pattern used by other sub-modules)

## Tests and docs
- update `tests/index.test.js` to assert exported component keys and empty-string return contract
- update `README.md` to document the new placeholder component API

## Scope
This PR only scaffolds structure and empty component placeholders; no runtime logic migration from `Work/` yet.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80b857f0-6772-4e4f-a6fa-8ab745641325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80b857f0-6772-4e4f-a6fa-8ab745641325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

