### PR TITLE
OuterTemplate Step 2: move HN definition source from Work

### DIFF
--- a/Work/src/templates/hn.js
+++ b/Work/src/templates/hn.js
@@ -1,15 +1,5 @@
-import { createTemplateFromDefinition } from './definitions/createTemplateFromDefinition';
-import hnDefinition from './definitions/hn.definition';
+import outerTemplateModule from 'atherdon-newsletter-js-layouts-outertemplate';
 
-/**
- * HN (Hacker News digest) email template.
- *
- * - Pass a plain string as `data` to render simple content.
- * - Pass `{ string, data }` (with a `data.title` / `data.preview`) to render
- *   the full front-matter variant.
- *
- * @type {import('./types').Template}
- */
-const hnTemplate = createTemplateFromDefinition(hnDefinition);
+const hnTemplate = outerTemplateModule.registry.hn;
 
 export default hnTemplate;

--- a/Work/tests/unit/outerTemplate.step2.hnDefinitionSource.unit.test.js
+++ b/Work/tests/unit/outerTemplate.step2.hnDefinitionSource.unit.test.js
@@ -1,0 +1,46 @@
+jest.mock('atherdon-newsletter-js-layouts-misc', () => ({
+  __esModule: true,
+  default: {
+    fontsComponent: () => '<fonts-component />',
+    addressComponent: ({ mailingAddress }) => `<address>${mailingAddress}</address>`,
+    copyrightsComponent: () => '<copyrights-component />',
+    newsletterSponsorshipLinkComponent: ({ contact }) => `<sponsor>${contact}</sponsor>`,
+    unsubscribeComponent: ({ unsubscribeLink }) => `<unsubscribe>${unsubscribeLink}</unsubscribe>`,
+  },
+}), { virtual: true });
+
+jest.mock('atherdon-newsletter-js-layouts-body', () => ({
+  __esModule: true,
+  default: {
+    logoTopComponent: () => '<logo-top-component />',
+    logoBottomComponent: () => '<logo-bottom-component />',
+  },
+}), { virtual: true });
+
+const { buildHnDefinition } = require('../../../sub-modules/outerTemplate/src/runtime/displayRuntimeDeps');
+const { mapHnInputToVariant } = require('@llazyemail/template-presets-hn');
+
+describe('outerTemplate step 2 definition source', () => {
+  test('hn registry definition uses preset package mapping function', () => {
+    const definition = buildHnDefinition();
+    expect(definition.mapData).toBe(mapHnInputToVariant);
+  });
+
+  test('hn registry definition retains display section metadata', () => {
+    const definition = buildHnDefinition();
+    expect(definition.sections).toEqual({
+      head: 'displayHead',
+      body: 'displayBody',
+      footer: 'displayFooter',
+      main: 'displayMain',
+    });
+  });
+
+  test('hn registry definition keeps expected feature flags', () => {
+    const definition = buildHnDefinition();
+    expect(definition.featureFlags).toEqual({
+      ads: true,
+      blocks: ['hero', 'ads', 'image-grid'],
+    });
+  });
+});

--- a/sub-modules/outerTemplate/src/index.js
+++ b/sub-modules/outerTemplate/src/index.js
@@ -19,10 +19,15 @@ const methods = {
   printTemplateData,
 };
 
+const templates = {
+  renderTemplate,
+  registry,
+};
+
 const outerTemplate = {
   ...components,
-  registry,
-  renderTemplate,
+  ...templates,
+  templates,
   methods,
   ...methods,
 };

--- a/sub-modules/outerTemplate/src/runtime/displayRuntimeDeps.js
+++ b/sub-modules/outerTemplate/src/runtime/displayRuntimeDeps.js
@@ -3,7 +3,8 @@ import { HeadHTMLString } from '../../../../Work/src/display/sections/head';
 import { BodyHTMLString } from '../../../../Work/src/display/sections/body';
 import { FooterHTMLString } from '../../../../Work/src/display/sections/footer';
 import { MainHTMLString } from '../../../../Work/src/display/sections/main';
-import { buildHnDefinition } from '../../../../Work/src/templates/definitions/hn-preset-adapters';
+import { validateHnTemplateInput } from '@llazyemail/template-engine';
+import { createHnPresetDefinition } from '@llazyemail/template-presets-hn';
 
 const displayDeps = {
   headString: HeadHTMLString,
@@ -11,6 +12,15 @@ const displayDeps = {
   footerString: FooterHTMLString,
   mainString: MainHTMLString,
 };
+
+const buildHnDefinition = () =>
+  createHnPresetDefinition({
+    renderers: {
+      simple: renderDisplayTemplate,
+      frontMatter: renderDisplayFrontMatterTemplate,
+    },
+    validateInput: validateHnTemplateInput,
+  });
 
 export {
   renderDisplayTemplate,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements **Step 2** of the outerTemplate migration by moving the **HN definition assembly source** out of `Work` and into `sub-modules/outerTemplate` runtime dependencies, while preserving `Work` compatibility behavior.

### What changed
- `sub-modules/outerTemplate/src/runtime/displayRuntimeDeps.js`
  - now composes `buildHnDefinition()` directly using:
    - `@llazyemail/template-presets-hn` (`createHnPresetDefinition`)
    - `@llazyemail/template-engine` validation (`validateHnTemplateInput`)
    - existing display renderers (`renderDisplayTemplate`, `renderDisplayFrontMatterTemplate`)
  - removes dependency on `Work/src/templates/definitions/hn-preset-adapters`

- `Work/src/templates/hn.js`
  - now delegates to `outerTemplate.registry.hn` directly

- `sub-modules/outerTemplate/src/index.js`
  - exports a `templates` namespace (`{ registry, renderTemplate }`) for clearer contract usage

### New tests
- `Work/tests/unit/outerTemplate.step2.hnDefinitionSource.unit.test.js`
  - verifies `buildHnDefinition()` uses `mapHnInputToVariant` from preset package
  - verifies section metadata and feature flags are preserved

## Validation
- `npm run test:unit -- outerTemplate.runtime.extended.unit.test.js outerTemplate.module.contract.unit.test.js outerTemplate.step2.hnDefinitionSource.unit.test.js templates.unit.test.js templateBehavior.freeze.unit.test.js templateValidation.unit.test.js templateEngine.contract.unit.test.js`
  - passed (27/27 suites)

## Scope
- step-2-only extraction of HN definition assembly source
- no intended rendering-output contract changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80b857f0-6772-4e4f-a6fa-8ab745641325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80b857f0-6772-4e4f-a6fa-8ab745641325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

