### PR TITLE
OuterTemplate Step 3: move hn-without-ads definition source from Work

### DIFF
--- a/Work/README.md
+++ b/Work/README.md
@@ -234,6 +234,32 @@ Workspace wiring updates:
 - `Work/package.json` now includes `../packages/template-runtime-display` in workspaces
 - `Work/package.json` now depends on `@llazyemail/template-runtime-display`
 
+### OuterTemplate migration — Step 3 (move `hn-without-ads` definition assembly source)
+
+Moved `hn-without-ads` runtime definition assembly into `sub-modules/outerTemplate`
+to continue extracting template runtime responsibilities from `Work` without changing
+the public `Work/src/templates/index.js` registry contract yet.
+
+What changed:
+
+- `sub-modules/outerTemplate/src/runtime/displayRuntimeDeps.js`
+  - now exports `buildHnWithoutAdsDefinition`
+  - composes it from:
+    - `createHnWithoutAdsPresetDefinition` (`@llazyemail/template-presets-hn`)
+    - display renderers (`renderDisplayTemplate`, `renderDisplayFrontMatterTemplate`)
+    - `validateHnWithoutAdsTemplateInput` (`@llazyemail/template-engine`)
+- `sub-modules/outerTemplate/src/index.js`
+  - now exports `buildHnWithoutAdsDefinition` for compatibility delegates
+- `Work/src/templates/hn-without-ads.js`
+  - now builds template via `buildHnWithoutAdsDefinition(...)` from `outerTemplate`
+  - keeps existing render/validation behavior for consumers
+
+Validation:
+
+- `tests/unit/outerTemplate.step3.hnWithoutAdsDefinitionSource.unit.test.js`
+  - verifies preset mapping source and metadata (`sections`, `featureFlags`)
+- existing contract tests still pass with registry shape unchanged (`['hn']`)
+
 ## Structure
 
 ```

--- a/Work/src/templates/hn-without-ads.js
+++ b/Work/src/templates/hn-without-ads.js
@@ -1,19 +1,13 @@
 import {
   createTemplateFromDefinition,
-  hnWithoutAdsDefinition,
-} from './definitions';
+  validateHnWithoutAdsTemplateInput,
+} from '@llazyemail/template-engine';
+import { buildHnWithoutAdsDefinition } from 'atherdon-newsletter-js-layouts-outertemplate';
 
-/**
- * HN (Hacker News digest) email template (without ads variant).
- *
- * - Pass a plain string as `data` to render simple content.
- * - Pass `{ string, data }` (with a `data.title` / `data.preview`) to render
- *   the full front-matter variant.
- *
- * @type {import('./types').Template}
- */
 const hnWithoutAdsTemplate = createTemplateFromDefinition(
-  hnWithoutAdsDefinition
+  buildHnWithoutAdsDefinition({
+    validateInput: validateHnWithoutAdsTemplateInput,
+  })
 );
 
 export default hnWithoutAdsTemplate;

--- a/Work/tests/unit/outerTemplate.step3.hnWithoutAdsDefinitionSource.unit.test.js
+++ b/Work/tests/unit/outerTemplate.step3.hnWithoutAdsDefinitionSource.unit.test.js
@@ -1,0 +1,50 @@
+jest.mock('atherdon-newsletter-js-layouts-misc', () => ({
+  __esModule: true,
+  default: {
+    fontsComponent: () => '<fonts-component />',
+    addressComponent: ({ mailingAddress }) => `<address>${mailingAddress}</address>`,
+    copyrightsComponent: () => '<copyrights-component />',
+    newsletterSponsorshipLinkComponent: ({ contact }) => `<sponsor>${contact}</sponsor>`,
+    unsubscribeComponent: ({ unsubscribeLink }) => `<unsubscribe>${unsubscribeLink}</unsubscribe>`,
+  },
+}), { virtual: true });
+
+jest.mock('atherdon-newsletter-js-layouts-body', () => ({
+  __esModule: true,
+  default: {
+    logoTopComponent: () => '<logo-top-component />',
+    logoBottomComponent: () => '<logo-bottom-component />',
+  },
+}), { virtual: true });
+
+const {
+  buildHnWithoutAdsDefinition,
+} = require('../../../sub-modules/outerTemplate/src/runtime/displayRuntimeDeps');
+const {
+  mapHnWithoutAdsInputToVariant,
+} = require('@llazyemail/template-presets-hn');
+
+describe('outerTemplate step 3 definition source', () => {
+  test('hn-without-ads definition uses preset package mapping function', () => {
+    const definition = buildHnWithoutAdsDefinition();
+    expect(definition.mapData).toBe(mapHnWithoutAdsInputToVariant);
+  });
+
+  test('hn-without-ads definition retains display section metadata', () => {
+    const definition = buildHnWithoutAdsDefinition();
+    expect(definition.sections).toEqual({
+      head: 'displayHead',
+      body: 'displayBody',
+      footer: 'displayFooter',
+      main: 'displayMain',
+    });
+  });
+
+  test('hn-without-ads definition keeps expected feature flags', () => {
+    const definition = buildHnWithoutAdsDefinition();
+    expect(definition.featureFlags).toEqual({
+      ads: false,
+      blocks: ['hero', 'image-grid'],
+    });
+  });
+});

--- a/sub-modules/outerTemplate/src/index.js
+++ b/sub-modules/outerTemplate/src/index.js
@@ -1,6 +1,7 @@
 import components from './components';
 import { renderTemplate } from './templates';
 import { registry } from './templates';
+import { buildHnWithoutAdsDefinition } from './runtime/displayRuntimeDeps';
 import {
   printMain,
   printFooter,
@@ -32,5 +33,5 @@ const outerTemplate = {
   ...methods,
 };
 
-export { registry, renderTemplate, methods };
+export { registry, renderTemplate, methods, buildHnWithoutAdsDefinition };
 export default outerTemplate;

--- a/sub-modules/outerTemplate/src/runtime/displayRuntimeDeps.js
+++ b/sub-modules/outerTemplate/src/runtime/displayRuntimeDeps.js
@@ -4,7 +4,13 @@ import { BodyHTMLString } from '../../../../Work/src/display/sections/body';
 import { FooterHTMLString } from '../../../../Work/src/display/sections/footer';
 import { MainHTMLString } from '../../../../Work/src/display/sections/main';
 import { validateHnTemplateInput } from '@llazyemail/template-engine';
-import { createHnPresetDefinition } from '@llazyemail/template-presets-hn';
+import {
+  createHnPresetDefinition,
+  createHnWithoutAdsPresetDefinition,
+} from '@llazyemail/template-presets-hn';
+import {
+  validateHnWithoutAdsTemplateInput,
+} from '@llazyemail/template-engine';
 
 const displayDeps = {
   headString: HeadHTMLString,
@@ -22,9 +28,19 @@ const buildHnDefinition = () =>
     validateInput: validateHnTemplateInput,
   });
 
+const buildHnWithoutAdsDefinition = () =>
+  createHnWithoutAdsPresetDefinition({
+    renderers: {
+      simple: renderDisplayTemplate,
+      frontMatter: renderDisplayFrontMatterTemplate,
+    },
+    validateInput: validateHnWithoutAdsTemplateInput,
+  });
+
 export {
   renderDisplayTemplate,
   renderDisplayFrontMatterTemplate,
   displayDeps,
   buildHnDefinition,
+  buildHnWithoutAdsDefinition,
 };

--- a/sub-modules/outerTemplate/src/templates/index.js
+++ b/sub-modules/outerTemplate/src/templates/index.js
@@ -1,6 +1,5 @@
 import { createRegistry, renderTemplate as renderTemplateById } from '@llazyemail/template-engine';
 import hnTemplate from './hn';
-
 export const registry = createRegistry([hnTemplate]);
 
 export const renderTemplate = (templateId, data) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- move `hn-without-ads` definition assembly into `sub-modules/outerTemplate/src/runtime/displayRuntimeDeps.js` via `buildHnWithoutAdsDefinition`
- export `buildHnWithoutAdsDefinition` from `sub-modules/outerTemplate/src/index.js` so `Work` can delegate safely
- update `Work/src/templates/hn-without-ads.js` to build from outerTemplate runtime source while preserving existing behavior
- keep `sub-modules/outerTemplate/src/templates/index.js` registry shape unchanged (`hn` only) to avoid behavior regressions during incremental migration
- document this migration slice in `Work/README.md`
- add `Work/tests/unit/outerTemplate.step3.hnWithoutAdsDefinitionSource.unit.test.js` to lock source, mapping, sections, and feature flags

## Validation
- `npm run test:unit -- outerTemplate.step3.hnWithoutAdsDefinitionSource.unit.test.js templateValidation.unit.test.js templates.unit.test.js outerTemplate.runtime.extended.unit.test.js templateBehavior.freeze.unit.test.js`
- result: all unit suites passing (28/28 in the test run output)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80b857f0-6772-4e4f-a6fa-8ab745641325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80b857f0-6772-4e4f-a6fa-8ab745641325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

